### PR TITLE
updated error message checks in tests that rely on assertthat::has_name

### DIFF
--- a/tests/testthat/test_community_stability.R
+++ b/tests/testthat/test_community_stability.R
@@ -45,7 +45,7 @@ test_that("community_stability loads and returns correct result", {
 
   #test that errors if subplot does not exist
   expect_error(stability_onerep(dat2agg, "subplot"),
-               "df does not have name subplot")
+              rexegp = "df does not have .*name.*subplot")
 
 
   #test the community_stability function

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -16,7 +16,7 @@ test_that("utilities loads and returns correct result", {
     # Does transpose_community correctly transform a long dataframe into a matrix?
     com_wide_df <- transpose_community(df = dat1, "year", "species", "abundance")
     expect_true(is.data.frame(com_wide_df))
-    
+
     df2 = subset(knz_001d, subplot == "A_1")
     names(df2)=c("spp", "yr", "subplot", "abund")
     com_wide_df <- transpose_community(df = df2, "yr", "spp", "abund")
@@ -33,48 +33,48 @@ test_that("Name checking works", {
   #                     sep=",", header=TRUE)
   expect_error(check_names(given = c("AAA", "year", "subplot", "abundance"),
                            data = knz_001d),
-                 "data does not have name .*")
+                 "data does not have .*name.*")
   expect_error(check_names(given = c("species", "BBB", "subplot", "abundance"),
                            data = knz_001d),
-               "data does not have name .*")
+               "data does not have .*name.*")
   expect_error(check_names(given = c("species", "year", "CCC", "abundance"),
                            data = knz_001d),
-               "data does not have name .*")
+               "data does not have .*name.*")
   expect_error(check_names(given = c("species", "year", "subplot", "DDD"),
                            data = knz_001d),
-               "data does not have name .*")
+               "data does not have .*name.*")
 })
 
 test_that("Single-record checks for species work", {
   data(knz_001d)
- 
+
   expect_null(check_single(knz_001d, time.var = "year", species.var = "species", replicate.var = "subplot"))
 
   knz_001d2<-knz_001d
   names(knz_001d2)=c("spp", "yr", "subp", "abund")
   expect_null(check_single(knz_001d2, time.var = "yr", species.var = "spp", replicate.var = "subp"))
-  
+
   dftog = rbind(knz_001d, knz_001d[nrow(knz_001d),])
   expect_error(check_single(dftog, time.var = "year", species.var = "species", replicate.var = "subplot"))
-  
+
   dftog2 = rbind(knz_001d2, knz_001d2[nrow(knz_001d2),])
   expect_error(check_single(dftog2, time.var = "yr", species.var = "spp", replicate.var = "subp"))
-  
-  
+
+
   dfa = subset(knz_001d, subplot == "A_1")
   expect_null(check_single_onerep(dfa, time.var = "year", species.var = "species"))
   dfab = subset(knz_001d, subplot == "A_1" | subplot == "A_2")
   expect_error(check_single_onerep(dfab, time.var = "year", species.var = "species"))
-  
+
   df2 = subset(knz_001d, subplot == "A_1")
   names(df2)=c("spp", "yr", "subplot", "abund")
   expect_null(check_single_onerep(df2, time.var = "yr", species.var = "spp"))
-  
+
   #check check_sppvar
   comdf <- as.data.frame(matrix(1, 5, 5))
   expect_error(check_sppvar(comdf))
-  
+
   comdf2 <-as.data.frame(matrix(c(1, 2, 3, 4, 5), 5, 5))
   check_sppvar(comdf2)
-  
+
   })


### PR DESCRIPTION
Hello,

We are currently in the process of updating `assertthat` (hadley/assertthat#59) and found that recent changes (namely hadley/assertthat#60) to `assertthat::has_name()` break you existing unit tests. Will you please consider this PR to adjust your test strategy?

Basically, `has_name()` previously had inconsistent behavior when given multiple names to check. That has been corrected and while correcting it, I slightly changed the error message raised by `assert_that(has_name(...))` calls.

I've confirmed that the slight change I'm proposing in this PR will allow your unit tests to pass with the current version of `assertthat` on CRAN (0.2.0) AND with the new version (0.2.1) when it is released.