### PR TITLE
Resolve error identified in R-devel CRAN checks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Version 2.0.5
+-------------
+
+BUG FIXES
+
+* Resolved silent error (no longer silent in R 4.1) from failure to use output
+  of `match.arg` (#122).
+
 Version 2.0.4
 -------------
 

--- a/R/community_diversity.R
+++ b/R/community_diversity.R
@@ -66,7 +66,7 @@ community_diversity <- function(df,
                                 metric = c("Shannon", "InverseSimpson")) {
   
   # verify measure choice
-  measure <- match.arg(metric)
+  metric <- match.arg(metric)
   
   # check no NAs in abundance column
   if (any(is.na(df[[abundance.var]]))) stop("Abundance column contains missing values")
@@ -81,9 +81,9 @@ community_diversity <- function(df,
   }
 
   # get function for chosen measure, and calculate output
-  diversity <- get(measure)
+  diversity <- get(metric)
   comdiv <- aggregate.data.frame(df[abundance.var], df[by], FUN = diversity)
-  names(comdiv) <- c(by, measure)
+  names(comdiv) <- c(by, metric)
   
   return(comdiv)
 }

--- a/R/community_structure.R
+++ b/R/community_structure.R
@@ -71,7 +71,7 @@ community_structure <- function(df,
                                 metric = c("Evar", "SimpsonEvenness", "EQ")) {
 
   # verify measure choice
-  measure <- match.arg(metric)
+  metric <- match.arg(metric)
   
   # check no NAs in abundance column
   if(any(is.na(df[[abundance.var]]))) stop("Abundance column contains missing values")
@@ -95,7 +95,7 @@ community_structure <- function(df,
     warning("Evenness values contain NAs because there are plots with only one species")
   }
   
-  names(comstruct) <- c(by, 'richness', measure)
+  names(comstruct) <- c(by, 'richness', metric)
 
   return(comstruct)
 }

--- a/R/synchrony.R
+++ b/R/synchrony.R
@@ -106,8 +106,8 @@ synchrony <- function(df, time.var,
 # @return output The degree of species synchrony. If "Loreau", 1 is perfect synchrony and 0 is perfect asynchrony.
 #        If "Gross", 1 is perfect synchrony and -1 is perfect asynchrony.
 synch_onerep <- function(df, time.var, species.var, abundance.var,
-                         metric = "Loreau") {
-    metric = match.arg(metric, choices = c("Loreau", "Gross")) # for partial argument matching
+                         metric = c("Loreau", "Gross")) {
+    metric = match.arg(metric) # for partial argument matching
 
     #remove any species that were never present.
     df <- subset(df, abundance.var > 0)


### PR DESCRIPTION
The upstream change revealed a valid bug in some uses of `match.arg`. I made all our uses consistent, fixing the bug. I have also updated NEWS. R CMD check under R-devel on macOS 11 gives no errors, warnings, or notes.

My environment for testing with R has severely deteriorated ... can @mbjones or @laurenmh merge this PR and complete CRAN release?

fixes #122